### PR TITLE
add back microsoft date format as JsonNetResult option

### DIFF
--- a/UCDArch/UCDArch.Web/ActionResults/JsonDateConversionStrategy.cs
+++ b/UCDArch/UCDArch.Web/ActionResults/JsonDateConversionStrategy.cs
@@ -12,7 +12,7 @@ namespace UCDArch.Web.ActionResults
     {
         Default,
         JavaScript,
-		Microsoft,
+        Microsoft,
         Iso
     }
 }

--- a/UCDArch/UCDArch.Web/ActionResults/JsonNetResult.cs
+++ b/UCDArch/UCDArch.Web/ActionResults/JsonNetResult.cs
@@ -32,9 +32,9 @@ namespace UCDArch.Web.ActionResults
                 case JsonDateConversionStrategy.Iso:
                     SerializerSettings.Converters.Add(new IsoDateTimeConverter());
                     break;
-				case JsonDateConversionStrategy.Microsoft:
-            		SerializerSettings.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat;
-            		break;
+                case JsonDateConversionStrategy.Microsoft:
+                    SerializerSettings.DateFormatHandling = DateFormatHandling.MicrosoftDateFormat;
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException("dateConversionStrategy");
             }


### PR DESCRIPTION
Scott - I've merged your COWS update locally and now I'm working on bringing it up to MVC4.  One small issue is the JSON.NET default date format changed.  This small update to UCDArch allows the old behavior.  Take a look and let me know if this seems right to you.  Thanks,

Ed
