### PR TITLE
remove non-standard port from URL in CASHelper

### DIFF
--- a/UCDArch/UCDArch.Web/Authentication/CASHelper.cs
+++ b/UCDArch/UCDArch.Web/Authentication/CASHelper.cs
@@ -8,7 +8,7 @@ namespace UCDArch.Web.Authentication
 {
     public static class CASHelper
     {
-        private const string StrCasUrl = "https://cas.ucdavis.edu:8443/cas/";
+        private const string StrCasUrl = "https://cas.ucdavis.edu/cas/";
         private const string StrTicket = "ticket";
         private const string StrReturnUrl = "ReturnURL";
 


### PR DESCRIPTION
Port 8443 for CAS is deprecated.  See tsp-share email 8/29/13.
This should make the new CAS EV cert appear correctly in browser
