### PR TITLE
Don't let IsInWebContext check explode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build UCDArch.Consolidated",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            // Set working directory for the task:
+            "options": {
+                "cwd": "${workspaceFolder}/UCDArch/UCDArch.Consolidated"
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/UCDArch/UCDArch.Consolidated/Core/SmartServiceLocator.cs
+++ b/UCDArch/UCDArch.Consolidated/Core/SmartServiceLocator.cs
@@ -1,6 +1,8 @@
 using System;
 using CommonServiceLocator;
 
+#nullable enable
+
 namespace UCDArch.Core
 {
     public static class SmartServiceLocator<DependencyT>
@@ -11,7 +13,13 @@ namespace UCDArch.Core
 
             try
             {
-                service = (DependencyT) ServiceLocator.Current.GetService(typeof (DependencyT));
+                object? resolved = ServiceLocator.Current.GetService(typeof(DependencyT));
+                if (resolved is null)
+                {
+                    throw new NullReferenceException("ServiceLocator returned null; " +
+                                                     "I was trying to retrieve " + typeof(DependencyT));
+                }
+                service = (DependencyT)resolved;
             }
             catch (NullReferenceException)
             {
@@ -31,6 +39,18 @@ namespace UCDArch.Core
             }
 
             return service;
+        }
+
+        public static DependencyT? TryGetService()
+        {
+            try
+            {
+                return (DependencyT?) ServiceLocator.Current.GetService(typeof(DependencyT));
+            }
+            catch
+            {
+                return default;
+            }
         }
     }
 }

--- a/UCDArch/UCDArch.Consolidated/Data/NHibernate/NHibernateSessionManager.cs
+++ b/UCDArch/UCDArch.Consolidated/Data/NHibernate/NHibernateSessionManager.cs
@@ -273,7 +273,7 @@ namespace UCDArch.Data.NHibernate
 
         private bool IsInWebContext()
         {
-            return SmartServiceLocator<Microsoft.AspNetCore.Http.IHttpContextAccessor>.GetService().HttpContext != null;
+            return (SmartServiceLocator<Microsoft.AspNetCore.Http.IHttpContextAccessor>.TryGetService()?.HttpContext) != null;
         }
 
         private const string TRANSACTION_KEY = "CONTEXT_TRANSACTION";

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ variables:
   buildConfiguration: 'Release'
   projectPath: 'UCDArch/UCDArch.Consolidated/UCDArch.Consolidated.csproj'
   majorVersion: 1
-  minorVersion: 0
+  minorVersion: 1
   patchVersion: $[counter(format('{0}.{1}', variables['majorVersion'], variables['minorVersion']), 0)]
   version: $(majorVersion).$(minorVersion).$(patchVersion)
   


### PR DESCRIPTION
Adds a TryGetService() method to SmartServiceLocator that returns default instead of throwing any exceptions.